### PR TITLE
Add a link to documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,21 @@ It includes collections and constants with text, numeric, and bit flag values.
 Originally ``twisted.python.constants`` from the `Twisted <https://twistedmatrix.com/>`_ project.
 
 
+Installing
+----------
+
+constantly is available in `PyPI <https://pypi.org/project/constantly/>`_,
+and can be installed via pip::
+
+  $ pip install constantly
+
+
+Documentation
+-------------------------
+
+Documentation is available at `<http://constantly.readthedocs.io/en/latest/>`_.
+
+
 Tests
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ and can be installed via pip::
 Documentation
 -------------------------
 
-Documentation is available at `<http://constantly.readthedocs.io/en/latest/>`_.
+Documentation is available at `<https://constantly.readthedocs.io/en/latest/>`_.
 
 
 Tests


### PR DESCRIPTION
Closes: #12, #16 

Would be nice to upload to PyPI so it shows up there in the rendered README, and possibly also changing the website here in GitHub so it shows up in the title bar.