### PR TITLE
 Spiff up the tox.ini, fixing the coverage build along the way.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+# vim: filetype=dosini:
+[run]
+branch = True
+source = constantly

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import codecs
 import os
 import versioneer
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 def read(*parts):
     """
@@ -35,7 +35,7 @@ if __name__ == "__main__":
         keywords="constants,enum,twisted",
         license="MIT",
         name="constantly",
-        packages=["constantly"],
+        packages=find_packages(),
         url="https://github.com/twisted/constantly",
         maintainer='Twisted Matrix Labs Developers',
         version=versioneer.get_version(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,40 +1,42 @@
 [tox]
 envlist = {py27,pypy,py33,py34}-tests, pyflakes, cov, docs
 
+[testenv]
+changedir = {envtmpdir}
+skipsdist=True
+deps =
+     twisted
+commands =
+    {envbindir}/pip install {toxinidir}
+    {envbindir}/trial {posargs:constantly}
+
+[testenv:cov]
+deps =
+    {[testenv]deps}
+    coverage
+commands =
+    {envbindir}/coverage run --rcfile={toxinidir}/.coveragerc {envbindir}/trial constantly
+    {envbindir}/coverage report --rcfile={toxinidir}/.coveragerc --show-missing --fail-under=100
+    {envbindir}/coverage html {posargs} --rcfile={toxinidir}/.coveragerc
+
 ###########################
 # Run pyflakes
 ###########################
 
 [testenv:pyflakes]
-skip_install = True
 deps = pyflakes
-commands = pyflakes constantly
-
-[testenv:cov]
-deps =
-    coverage
-    twisted
-commands =
-    coverage run {envbindir}/trial constantly
-    coverage report --include=constantly/* --omit=constantly/_version.py --fail-under=100
-    coverage html --include=constantly/* --omit=constantly/_version.py
+commands = {envbindir}/pyflakes {toxinidir}/constantly
 
 [testenv:docs]
-skip_install = True
 deps = sphinx
 basepython = python2.7
 commands =
-     sphinx-build -W -b html docs docs/_build/html
+     {envbindir}/sphinx-build -W -b html {toxinidir}/docs {toxinidir}/docs/_build/html
 
 [testenv:apidocs]
 deps =
     epydoc
     pydoctor
 commands =
-    pydoctor -q --prepend-package zope --project-name zope.interface --add-package {envsitepackagesdir}/zope/interface -o zope.interface.system
-    pydoctor -q --system-class pydoctor.twistedmodel.TwistedSystem --project-name constantly --extra-system=zope.interface.system:https://zope.org/ constantly
-
-[testenv]
-deps =
-     twisted
-commands = trial constantly
+    {envbindir}/pydoctor -q --prepend-package zope --project-name zope.interface --add-package {envsitepackagesdir}/zope/interface -o zope.interface.system
+    {envbindir}/pydoctor -q --system-class pydoctor.twistedmodel.TwistedSystem --project-name constantly --extra-system=zope.interface.system:https://zope.org/ constantly


### PR DESCRIPTION

Spiff up the tox.ini, fixing the coverage build along the way.  …
* Absolute paths everywhere, via tox.ini variables
* Adds a .coverage.ini to persist our coverage settings (and enable
branch coverage by default)
* Uses skipsdist, taking over full control over exactly which testenvs
  even bother doing anything install-related

Closes: #18