### PR TITLE
#40 Publish to PyPi using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
 
+
 # Only have a run a single parallel for each branch.
 # Runs for trunk are queues.
 # Older runs for non-trunk branches are cancelled and the jobs are executed
@@ -55,15 +56,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
-    - name: Test build
-      run: pipx run --python=python build .
-
     - name: Install dependencies
       run: |
-        openssl version
-        python -m pip install --upgrade twisted coverage build
+        python -m pip install --upgrade twisted coverage
 
-    - name: Test
+    - name: Test code
       run: |
         coverage run -m twisted.trial constantly
         mv .coverage .coverage.${{ matrix.python-version }}
@@ -74,6 +71,7 @@ jobs:
         name: coverage-data
         path: .coverage.*
         if-no-files-found: error # 'warn' or 'ignore' are also available.
+
 
   coverage:
     name: Combine & check coverage.
@@ -163,23 +161,34 @@ jobs:
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
 
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade build
+
     - name: Build
       run: |
         rm -rf dist/*
-        pipx run --python=python build .
+        python -m build .
 
     - name: Files to be pushed to PyPi
       run: ls -R dist/
 
-    - name: Check matched tag version and branch version - on tag
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        python -Im pip install --upgrade pep517
-        python admin/check_tag_version_match.py "${{ github.ref }}"
+    # FIXME:
+    # Remove comment after testing,
+    # - name: Check matched tag version and branch version - on tag
+    #   if: startsWith(github.ref, 'refs/tags/')
+    #   run: |
+    #     python -Im pip install --upgrade pep517
+    #     python admin/check_tag_version_match.py "${{ github.ref }}"
 
     - name: Publish to PyPI - on tag
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+      # FIXME:
+      # Remove comment after testing,
+      # if: startsWith(github.ref, 'refs/tags/')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      # Uncomment to run on testing.
+      with:
+        repository-url: https://test.pypi.org/legacy/
 
 
   # We have this job so that the PR can be blocked on a single job.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,6 @@ on:
 permissions:
   contents: read
 
-
 # Only have a run a single parallel for each branch.
 # Runs for trunk are queues.
 # Older runs for non-trunk branches are cancelled and the jobs are executed
@@ -153,6 +152,10 @@ jobs:
   release-publish:
     name: Check release and publish on twisted-* tag
     runs-on: 'ubuntu-latest'
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade twisted coverage
+        python -m pip install --upgrade twisted coverage build
+
+    - name: Test build on each supported python
+      run: python -m build .
 
     - name: Test code
       run: |
@@ -176,22 +179,15 @@ jobs:
     - name: Files to be pushed to PyPi
       run: ls -R dist/
 
-    # FIXME:
-    # Remove comment after testing,
-    # - name: Check matched tag version and branch version - on tag
-    #   if: startsWith(github.ref, 'refs/tags/')
-    #   run: |
-    #     python -Im pip install --upgrade pep517
-    #     python admin/check_tag_version_match.py "${{ github.ref }}"
+    - name: Check matched tag version and branch version - on tag
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        python -Im pip install --upgrade pep517
+        python admin/check_tag_version_match.py "${{ github.ref }}"
 
     - name: Publish to PyPI - on tag
-      # FIXME:
-      # Remove comment after testing,
-      # if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/')
       uses: pypa/gh-action-pypi-publish@release/v1
-      # Uncomment to run on testing.
-      with:
-        repository-url: https://test.pypi.org/legacy/
 
 
   # We have this job so that the PR can be blocked on a single job.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
+    - name: Test build
+      run: pipx run --python=python build .
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade twisted coverage build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ versionfile_source = "constantly/_version.py"
 versionfile_build = "constantly/_version.py"
 tag_prefix = ""
 parentdir_prefix = "constantly-"
+
+[bdist_wheel]
+universal=0


### PR DESCRIPTION
Fixes #40

It was the `ci.yaml vs ci.yml` but also the write permission for the token was missing. 

---------

A push to testing looks ok  ... it fails as the version was not ok, as it was not generated for a tag.


https://github.com/twisted/constantly/actions/runs/6690686556/job/18176460120?pr=41#step:8:20


I don't know how to override versioneer: https://github.com/python-versioneer/python-versioneer/issues/199