### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,9 +199,11 @@ jobs:
 
     - name: Check matched tag version and branch version - on tag
       if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GITHUB_REF: "${{ github.ref }}"
       run: |
         python -Im pip install --upgrade pep517
-        python admin/check_tag_version_match.py "${{ github.ref }}"
+        python admin/check_tag_version_match.py "$GITHUB_REF"
 
     - name: Publish to PyPI - on tag
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,12 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -84,8 +86,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
+    - uses: actions/setup-python@v6
       with:
         # Use latest Python, so it understands all syntax.
         python-version: 3.14
@@ -112,13 +117,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         # Need full history for various diff checks to work.
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
 
@@ -136,9 +142,12 @@ jobs:
     name: API docs build
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
     - name: Install dependencies
@@ -167,10 +176,12 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '${{ env.DEFAULT_PYTHON_VERSION }}'
 


### PR DESCRIPTION
Per [Adi's suggestion](https://github.com/twisted/constantly/pull/47#discussion_r3136001691), update a few actions.

I also ran [Zizmor](https://docs.zizmor.sh) and addressed a finding. I didn't hash-pin the actions as we are only using official actions and [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish), all of which seem safe enough to let float.
